### PR TITLE
Add ec2 SecurityGroup (SG) tagging

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
-# Awstaghelper
+# AWSTagHelper
 
-### Painless AWS tagging
+## Painless AWS tagging
 
 Tags are critical to managing AWS resources at scale. Awstaghelper provides a command line tool to ease adding and managing tags to and from CSV files across the wide range of AWS resources.
 
@@ -10,6 +10,7 @@ Tags are critical to managing AWS resources at scale. Awstaghelper provides a co
 * [Installing](#installing)
 * [Getting Started](#getting-started)
   * [Ec2](#ec2)
+  * [Ec2 SecurityGroup](#ec2sg)
   * [Rds](#rds)
   * [Lambda](#lambda)
   * [S3](#s3)
@@ -53,6 +54,18 @@ Read csv and tag ec2 - `awstaghelper ec2 tag-ec2`
 Example:
  `awstaghelper ec2 tag-ec2 --filename ec2Tag.csv --profile main`  
 
+#### Get security group tags
+
+Get list of SGs with required tags - `awstaghelper ec2 get-sg-tags`  
+Example:
+ `awstaghelper ec2 get-sg-tags --filename sgTag.csv --tags Name,Owner --profile main`
+
+#### Tag security group
+
+Read csv and tag ec2 - `awstaghelper ec2 tag-sg`  
+Example:
+ `awstaghelper ec2 tag-sg --filename sgTag.csv --profile main`  
+
 ### Rds
 
 #### Get rds tags
@@ -94,7 +107,7 @@ Example:
 Read csv and tag s3 - `awstaghelper s3 tag-s3`  
 Example:
  `awstaghelper s3 tag-s3 --filename ec2Tag.csv --profile main`  
- 
+
 ### Elasticache
 
 #### Get elasticache tags

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,9 +1,12 @@
 # https://taskfile.dev
 
-version: '3'
-
+version: "3"
 
 tasks:
+  install:
+    desc: install binary on $GOPATH/bin
+    cmds:
+      - cmd: go install
   test:
     desc: run tests
     cmds:

--- a/cmd/cloudfront.go
+++ b/cmd/cloudfront.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/cloudwatch.go
+++ b/cmd/cloudwatch.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/ecr.go
+++ b/cmd/ecr.go
@@ -13,10 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (
 	"awstaghelper/pkg"
+
 	"github.com/aws/aws-sdk-go/service/ecr"
 
 	"github.com/spf13/cobra"

--- a/cmd/elasticache.go
+++ b/cmd/elasticache.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/elasticsearch.go
+++ b/cmd/elasticsearch.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/elb.go
+++ b/cmd/elb.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -13,10 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (
 	"awstaghelper/pkg"
+
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/spf13/cobra"
 )

--- a/cmd/kinesis.go
+++ b/cmd/kinesis.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/lambda.go
+++ b/cmd/lambda.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/rds.go
+++ b/cmd/rds.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/redshift.go
+++ b/cmd/redshift.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd is the package for the CLI of awstaghelper
 package cmd
 
 import (

--- a/cmd/sg.go
+++ b/cmd/sg.go
@@ -24,21 +24,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ec2Cmd represents the ec2 command
-var ec2Cmd = &cobra.Command{
-	Use:   "ec2",
-	Short: "Root command for interaction with AWS ec2 services",
-	Long:  `Root command for interaction with AWS ec2 services.`,
-	//Run: func(cmd *cobra.Command, args []string) {
-	//	fmt.Println("ec2 called")
-	//},
-}
-
-var getEc2Cmd = &cobra.Command{
-	Use:   "get-ec2-tags",
-	Short: "Write ec2 id and required tags to csv",
-	Long: `Write to csv data with ec2 id and required tags to csv. 
-This csv can be used with tag-ec2 command to tag aws environment.
+var getSecurityGroupsCmd = &cobra.Command{
+	Use:   "get-sg-tags",
+	Short: "Write sg id and required tags to csv",
+	Long: `Write to csv data with sg id and required tags to csv. 
+This csv can be used with tag-sg command to tag aws environment.
 Specify list of tags which should be read using tags flag: --tags Name,Env,Project.
 Csv filename can be specified with flag filename.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -48,14 +38,14 @@ Csv filename can be specified with flag filename.`,
 		region, _ := cmd.Flags().GetString("region")
 		sess := pkg.GetSession(region, profile)
 		client := ec2.New(sess)
-		pkg.WriteCsv(pkg.ParseEC2Tags(tags, client), filename)
+		pkg.WriteCsv(pkg.ParseSecurityGroupTags(tags, client), filename)
 	},
 }
 
-var tagEc2Cmd = &cobra.Command{
-	Use:   "tag-ec2",
-	Short: "Read csv and tag ec2 with csv data",
-	Long:  `Read csv generated with get-ec2-tags command and tag ec2 instances with tags from csv.`,
+var tagSecurityGroupsCmd = &cobra.Command{
+	Use:   "tag-sg",
+	Short: "Read csv and tag sg with csv data",
+	Long:  `Read csv generated with get-sg-tags command and tag sg resources with tags from csv.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		filename, _ := cmd.Flags().GetString("filename")
 		profile, _ := cmd.Flags().GetString("profile")
@@ -63,12 +53,11 @@ var tagEc2Cmd = &cobra.Command{
 		sess := pkg.GetSession(region, profile)
 		csvData := pkg.ReadCsv(filename)
 		client := ec2.New(sess)
-		pkg.TagEc2(csvData, client)
+		pkg.TagSecurityGroups(csvData, client)
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(ec2Cmd)
-	ec2Cmd.AddCommand(getEc2Cmd)
-	ec2Cmd.AddCommand(tagEc2Cmd)
+	ec2Cmd.AddCommand(getSecurityGroupsCmd)
+	ec2Cmd.AddCommand(tagSecurityGroupsCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module awstaghelper
 go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.35.9
+	github.com/aws/aws-sdk-go v1.35.13
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.35.9 h1:b1HiUpdkFLJyoOQ7zas36YHzjNHH0ivHx/G5lWBeg+U=
 github.com/aws/aws-sdk-go v1.35.9/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
+github.com/aws/aws-sdk-go v1.35.13 h1:Y49GifH2czbooBMkVpoXwokur1JRBFKVLVCQzO0YsW8=
+github.com/aws/aws-sdk-go v1.35.13/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/pkg/aws.go
+++ b/pkg/aws.go
@@ -2,12 +2,14 @@ package pkg
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
+// GetSession retrieves the AWS session if possible
 func GetSession(region string, profile string) *session.Session {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Profile: profile,

--- a/pkg/cloudfront.go
+++ b/pkg/cloudfront.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudfront/cloudfrontiface"
-	"log"
 )
 
 // getDistributions return all cloudfront distributions from specified region
@@ -14,7 +15,7 @@ func getDistributions(client cloudfrontiface.CloudFrontAPI) *cloudfront.ListDist
 
 	result, err := client.ListDistributions(input)
 	if err != nil {
-		log.Fatal("Not able to get distributions", err)
+		log.Fatal("Not able to get distributions ", err)
 		return nil
 	}
 	return result
@@ -31,7 +32,7 @@ func ParseDistributionsTags(tagsToRead string, client cloudfrontiface.CloudFront
 		}
 		distributionTags, err := client.ListTagsForResource(input)
 		if err != nil {
-			fmt.Println("Not able to get distributions tags", err)
+			fmt.Println("Not able to get distributions tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range distributionTags.Tags.Items {

--- a/pkg/cloudwatch.go
+++ b/pkg/cloudwatch.go
@@ -2,12 +2,13 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
-	"log"
 )
 
 // getCWAlarm return all CloudWatch alarms from specified region
@@ -22,7 +23,7 @@ func getCWAlarm(client cloudwatchiface.CloudWatchAPI) []*cloudwatch.MetricAlarm 
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get alarms", err)
+		log.Fatal("Not able to get alarms ", err)
 		return nil
 	}
 	return result
@@ -39,7 +40,7 @@ func ParseCwAlarmTags(tagsToRead string, client cloudwatchiface.CloudWatchAPI) [
 		}
 		cwLogTags, err := client.ListTagsForResource(input)
 		if err != nil {
-			fmt.Println("Not able to get alarm tags", err)
+			fmt.Println("Not able to get alarm tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range cwLogTags.Tags {
@@ -62,7 +63,7 @@ func getCWLogGroups(client cloudwatchlogsiface.CloudWatchLogsAPI) []*cloudwatchl
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get log groups", err)
+		log.Fatal("Not able to get log groups ", err)
 		return nil
 	}
 	return result
@@ -79,7 +80,7 @@ func ParseCwLogGroupTags(tagsToRead string, client cloudwatchlogsiface.CloudWatc
 		}
 		cwLogTags, err := client.ListTagsLogGroup(input)
 		if err != nil {
-			fmt.Println("Not able to get log group tags", err)
+			fmt.Println("Not able to get log group tags ", err)
 		}
 		tags := map[string]string{}
 		for key, value := range cwLogTags.Tags {

--- a/pkg/config_rule.go
+++ b/pkg/config_rule.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/aws/aws-sdk-go/service/configservice/configserviceiface"
-	"log"
 )
 
 // getConfigRules return all config rules from specified region
@@ -14,7 +15,7 @@ func getConfigRules(client configserviceiface.ConfigServiceAPI) *configservice.D
 
 	result, err := client.DescribeConfigRules(input)
 	if err != nil {
-		log.Fatal("Not able to get config rules", err)
+		log.Fatal("Not able to get config rules ", err)
 		return nil
 	}
 	return result
@@ -31,7 +32,7 @@ func ParseConfigRuleTags(tagsToRead string, client configserviceiface.ConfigServ
 		}
 		configTags, err := client.ListTagsForResource(input)
 		if err != nil {
-			fmt.Println("Not able to get config rule tags", err)
+			fmt.Println("Not able to get config rule tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range configTags.Tags {

--- a/pkg/csv.go
+++ b/pkg/csv.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// WriteCsv writes the csv data to disk
 func WriteCsv(data [][]string, filename string) {
 	file, err := os.Create(filename)
 	if err != nil {
@@ -25,6 +26,7 @@ func WriteCsv(data [][]string, filename string) {
 	}
 }
 
+// ReadCsv reads a csv file from disk
 func ReadCsv(filename string) [][]string {
 	csvFile, err := os.Open(filename)
 	if err != nil {
@@ -40,19 +42,19 @@ func ReadCsv(filename string) [][]string {
 	return csvLines
 }
 
-func addHeadersToCsv(tagsToRead string, resourceIdHeader string) [][]string {
+func addHeadersToCsv(tagsToRead string, resourceIDHeader string) [][]string {
 	var rows [][]string
-	headers := []string{resourceIdHeader}
+	headers := []string{resourceIDHeader}
 	headers = append(headers, strings.Split(tagsToRead, ",")...)
 	rows = append(rows, headers)
 	return rows
 }
 
-func addTagsToCsv(tagsToRead string, tags map[string]string, rows [][]string, resourceId string) [][]string {
+func addTagsToCsv(tagsToRead string, tags map[string]string, rows [][]string, resourceID string) [][]string {
 	var resultTags []string
 	for _, key := range strings.Split(tagsToRead, ",") {
 		resultTags = append(resultTags, tags[key])
 	}
-	rows = append(rows, append([]string{resourceId}, resultTags...))
+	rows = append(rows, append([]string{resourceID}, resultTags...))
 	return rows
 }

--- a/pkg/ec2.go
+++ b/pkg/ec2.go
@@ -1,10 +1,11 @@
 package pkg
 
 import (
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"log"
 )
 
 // getEC2Instances return all ec2 instances from specified region
@@ -19,7 +20,7 @@ func getEC2Instances(client ec2iface.EC2API) []*ec2.Reservation {
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get ec2 instances", err)
+		log.Fatal("Not able to get EC2 instances ", err)
 	}
 	return result
 }

--- a/pkg/ec2_sg.go
+++ b/pkg/ec2_sg.go
@@ -1,0 +1,65 @@
+package pkg
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+)
+
+// getSecurityGroups return all security groups from specified region
+func getSecurityGroups(client ec2iface.EC2API) []*ec2.SecurityGroup {
+	input := &ec2.DescribeSecurityGroupsInput{}
+
+	var result []*ec2.SecurityGroup
+
+	err := client.DescribeSecurityGroupsPages(input,
+		func(page *ec2.DescribeSecurityGroupsOutput, lastPage bool) bool {
+			result = append(result, page.SecurityGroups...)
+			return !lastPage
+		})
+	if err != nil {
+		log.Fatal("Not able to get security groups ", err)
+	}
+	return result
+}
+
+// ParseSecurityGroupTags parse output from getSecurityGroups and return SG ids and specified tags.
+func ParseSecurityGroupTags(tagsToRead string, client ec2iface.EC2API) [][]string {
+	groupsOutput := getSecurityGroups(client)
+	rows := addHeadersToCsv(tagsToRead, "Id")
+	for _, sg := range groupsOutput {
+		tags := map[string]string{}
+		for _, tag := range sg.Tags {
+			tags[*tag.Key] = *tag.Value
+		}
+		rows = addTagsToCsv(tagsToRead, tags, rows, *sg.GroupId)
+	}
+	return rows
+}
+
+// TagSecurityGroups tag security groups. Take as input data from csv file. Where first column id
+func TagSecurityGroups(csvData [][]string, client ec2iface.EC2API) {
+	for r := 1; r < len(csvData); r++ {
+		var tags []*ec2.Tag
+		for c := 1; c < len(csvData[0]); c++ {
+			tags = append(tags, &ec2.Tag{
+				Key:   &csvData[0][c],
+				Value: &csvData[r][c],
+			})
+		}
+
+		input := &ec2.CreateTagsInput{
+			Resources: []*string{
+				aws.String(csvData[r][0]),
+			},
+			Tags: tags,
+		}
+
+		_, err := client.CreateTags(input)
+		if awsErrorHandle(err) {
+			return
+		}
+	}
+}

--- a/pkg/ec2_sg_test.go
+++ b/pkg/ec2_sg_test.go
@@ -1,0 +1,82 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockedSecurityGroup struct {
+	ec2iface.EC2API
+	respDescribeSecurityGroups ec2.DescribeSecurityGroupsOutput
+}
+
+// AWS Mocks
+func (m *mockedSecurityGroup) DescribeSecurityGroupsPages(
+	input *ec2.DescribeSecurityGroupsInput,
+	pageFunc func(*ec2.DescribeSecurityGroupsOutput, bool) bool) error {
+	pageFunc(&m.respDescribeSecurityGroups, true)
+	return nil
+}
+
+// Tests
+func TestGetSecurityGroups(t *testing.T) {
+	cases := []*mockedSecurityGroup{
+		{
+			respDescribeSecurityGroups: parseSecurityGroupTagsResponse,
+		},
+	}
+
+	expectedResult := parseSecurityGroupTagsResponse.SecurityGroups
+
+	for _, c := range cases {
+		t.Run("GetSecurityGroups", func(t *testing.T) {
+			result := getSecurityGroups(c)
+			assertions := assert.New(t)
+			assertions.EqualValues(expectedResult, result)
+		})
+
+	}
+}
+
+func TestParseSecurityGroupTags(t *testing.T) {
+	cases := []*mockedSecurityGroup{
+		{
+			respDescribeSecurityGroups: parseSecurityGroupTagsResponse,
+		},
+	}
+	expectedResult := [][]string{
+		{"Id", "Name", "Environment", "Owner"},
+		{"sg-test", "TestSecurityGroup1", "Test", ""},
+	}
+	for _, c := range cases {
+		t.Run("ParseSecurityGroupTags", func(t *testing.T) {
+			result := ParseSecurityGroupTags("Name,Environment,Owner", c)
+			assertions := assert.New(t)
+			assertions.EqualValues(expectedResult, result)
+		})
+	}
+}
+
+var parseSecurityGroupTagsResponse = ec2.DescribeSecurityGroupsOutput{
+	SecurityGroups: []*ec2.SecurityGroup{
+		{
+			Description: aws.String("testSg"),
+			GroupId:     aws.String("sg-test"),
+			GroupName:   aws.String("testSg"),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("Name"),
+					Value: aws.String("TestSecurityGroup1"),
+				},
+				{
+					Key:   aws.String("Environment"),
+					Value: aws.String("Test"),
+				},
+			},
+		},
+	},
+}

--- a/pkg/ecr.go
+++ b/pkg/ecr.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
-	"log"
 )
 
 func getEcrRepositories(client ecriface.ECRAPI) []*ecr.Repository {
@@ -19,7 +20,7 @@ func getEcrRepositories(client ecriface.ECRAPI) []*ecr.Repository {
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get ecr repositories", err)
+		log.Fatal("Not able to get ecr repositories ", err)
 		return nil
 	}
 	return result
@@ -32,7 +33,7 @@ func ParseEcrRepositoriesTags(tagsToRead string, client ecriface.ECRAPI) [][]str
 	for _, repo := range repoList {
 		repoTags, err := client.ListTagsForResource(&ecr.ListTagsForResourceInput{ResourceArn: repo.RepositoryArn})
 		if err != nil {
-			fmt.Println("Not able to get ecr tags", err)
+			fmt.Println("Not able to get ecr tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range repoTags.Tags {

--- a/pkg/elastic_search.go
+++ b/pkg/elastic_search.go
@@ -2,12 +2,13 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/aws/aws-sdk-go/service/elasticsearchservice/elasticsearchserviceiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"log"
 )
 
 // getElasticSearchDomains return all elasticsearch from specified region
@@ -16,7 +17,7 @@ func getElasticSearchDomains(client elasticsearchserviceiface.ElasticsearchServi
 
 	result, err := client.ListDomainNames(input)
 	if err != nil {
-		log.Fatal("Not able to get elasticsearch instances", err)
+		log.Fatal("Not able to get elasticsearch instances ", err)
 	}
 	return result
 }
@@ -26,7 +27,7 @@ func ParseElasticSearchTags(tagsToRead string, client elasticsearchserviceiface.
 	instancesOutput := getElasticSearchDomains(client)
 	callerIdentity, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
-		log.Fatal("Not able to get account id", err)
+		log.Fatal("Not able to get account id ", err)
 	}
 	rows := addHeadersToCsv(tagsToRead, "Arn")
 	for _, elasticCacheInstance := range instancesOutput.DomainNames {
@@ -39,7 +40,7 @@ func ParseElasticSearchTags(tagsToRead string, client elasticsearchserviceiface.
 		}
 		elasticSearchTags, err := client.ListTags(input)
 		if err != nil {
-			fmt.Println("Not able to get elasticsearch tags", err)
+			fmt.Println("Not able to get elasticsearch tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range elasticSearchTags.TagList {

--- a/pkg/elasticache.go
+++ b/pkg/elasticache.go
@@ -2,12 +2,13 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"log"
 )
 
 // getElastiCacheClusters return all ElastiCache from specified region
@@ -22,7 +23,7 @@ func getElastiCacheClusters(client elasticacheiface.ElastiCacheAPI) []*elasticac
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get elasticache instances", err)
+		log.Fatal("Not able to get elasticache instances ", err)
 		return nil
 	}
 	return result
@@ -33,7 +34,7 @@ func ParseElastiCacheClusterTags(tagsToRead string, client elasticacheiface.Elas
 	instancesOutput := getElastiCacheClusters(client)
 	callerIdentity, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
-		log.Fatal("Not able to get account id", err)
+		log.Fatal("Not able to get account id ", err)
 	}
 	rows := addHeadersToCsv(tagsToRead, "Arn")
 	for _, elasticCacheInstance := range instancesOutput {
@@ -46,7 +47,7 @@ func ParseElastiCacheClusterTags(tagsToRead string, client elasticacheiface.Elas
 		}
 		elasticCacheTag, err := client.ListTagsForResource(input)
 		if err != nil {
-			fmt.Println("Not able to get elasticache tags", err)
+			fmt.Println("Not able to get elasticache tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range elasticCacheTag.TagList {

--- a/pkg/elb.go
+++ b/pkg/elb.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
-	"log"
 )
 
 // getElbV2 return all elbv2 (application and network) instances from specified region
@@ -20,7 +21,7 @@ func getElbV2(client elbv2iface.ELBV2API) []*elbv2.LoadBalancer {
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get load balancers", err)
+		log.Fatal("Not able to get load balancers ", err)
 		return nil
 	}
 	return result
@@ -33,7 +34,7 @@ func ParseElbV2Tags(tagsToRead string, client elbv2iface.ELBV2API) [][]string {
 	for _, elb := range instancesOutput {
 		elbTags, err := client.DescribeTags(&elbv2.DescribeTagsInput{ResourceArns: []*string{elb.LoadBalancerArn}})
 		if err != nil {
-			fmt.Println("Not able to get load balancer tags", err)
+			fmt.Println("Not able to get load balancer tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tagsToWrite := range elbTags.TagDescriptions {

--- a/pkg/iam.go
+++ b/pkg/iam.go
@@ -2,11 +2,12 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"log"
-	"strings"
 )
 
 func getIamUsers(client iamiface.IAMAPI) []*iam.User {
@@ -20,7 +21,7 @@ func getIamUsers(client iamiface.IAMAPI) []*iam.User {
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get iam users", err)
+		log.Fatal("Not able to get IAM users ", err)
 		return nil
 	}
 	return result
@@ -36,7 +37,7 @@ func ParseIamUserTags(tagsToRead string, client iamiface.IAMAPI) [][]string {
 	for _, user := range usersList {
 		userTags, err := client.ListUserTags(&iam.ListUserTagsInput{UserName: user.UserName})
 		if err != nil {
-			fmt.Println("Not able to get iam user tags", err)
+			fmt.Println("Not able to get IAM user tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range userTags.Tags {
@@ -81,7 +82,7 @@ func getIamRoles(client iamiface.IAMAPI) []*iam.Role {
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get iam roles", err)
+		log.Fatal("Not able to get IAM roles ", err)
 		return nil
 	}
 	return result

--- a/pkg/kinesis.go
+++ b/pkg/kinesis.go
@@ -2,12 +2,13 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
-	"log"
 )
 
 // getFirehoses return all firehoses from specified region
@@ -21,7 +22,7 @@ func getFirehoses(client firehoseiface.FirehoseAPI) *firehose.ListDeliveryStream
 	return result
 }
 
-// ParseKinesisTags parse output from getFirehoses and return firehose name and specified tags.
+// ParseFirehoseTags parse output from getFirehoses and return firehose name and specified tags.
 func ParseFirehoseTags(tagsToRead string, client firehoseiface.FirehoseAPI) [][]string {
 	instancesOutput := getFirehoses(client)
 	rows := addHeadersToCsv(tagsToRead, "Name")

--- a/pkg/lambda.go
+++ b/pkg/lambda.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
-	"log"
 )
 
 // getLambdaFunctions return all lambdas from specified region
@@ -20,7 +21,7 @@ func getLambdaFunctions(client lambdaiface.LambdaAPI) []*lambda.FunctionConfigur
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get lambdas", err)
+		log.Fatal("Not able to get lambdas ", err)
 		return nil
 	}
 	return result
@@ -33,7 +34,7 @@ func ParseLambdaFunctionTags(tagsToRead string, client lambdaiface.LambdaAPI) []
 	for _, lambdaOutput := range instancesOutput {
 		lambdaTags, err := client.ListTags(&lambda.ListTagsInput{Resource: lambdaOutput.FunctionArn})
 		if err != nil {
-			fmt.Println("Not able to get lambda tags", err)
+			fmt.Println("Not able to get lambda tags ", err)
 		}
 		tags := map[string]string{}
 		for key, value := range lambdaTags.Tags {

--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
-	"log"
 )
 
 // getRDSInstances return all rds instances from specified region
@@ -33,7 +34,7 @@ func ParseRDSTags(tagsToRead string, client rdsiface.RDSAPI) [][]string {
 	for _, dbInstances := range instancesOutput {
 		rdsTags, err := client.ListTagsForResource(&rds.ListTagsForResourceInput{ResourceName: dbInstances.DBInstanceArn})
 		if err != nil {
-			fmt.Println("Not able to get rds tags", err)
+			fmt.Println("Not able to get rds tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range rdsTags.TagList {

--- a/pkg/redshift.go
+++ b/pkg/redshift.go
@@ -2,12 +2,13 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"log"
 )
 
 // getRedshiftInstances return all redshift instances from specified region
@@ -22,7 +23,7 @@ func getRedshiftInstances(client redshiftiface.RedshiftAPI) []*redshift.Cluster 
 			return !lastPage
 		})
 	if err != nil {
-		log.Fatal("Not able to get redshift instances", err)
+		log.Fatal("Not able to get redshift instances ", err)
 		return nil
 	}
 	return result
@@ -42,7 +43,7 @@ func ParseRedshiftTags(tagsToRead string, client redshiftiface.RedshiftAPI, stsC
 			region, *callerIdentity.Account, *redshiftInstances.ClusterIdentifier)
 		redshiftTags, err := client.DescribeTags(&redshift.DescribeTagsInput{ResourceName: &clusterArn})
 		if err != nil {
-			fmt.Println("Not able to get redshift tags", err)
+			fmt.Println("Not able to get redshift tags ", err)
 		}
 		tags := map[string]string{}
 		for _, tag := range redshiftTags.TaggedResources {

--- a/pkg/s3.go
+++ b/pkg/s3.go
@@ -2,11 +2,12 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"log"
 )
 
 // getBuckets return all s3 buckets from specified region
@@ -15,7 +16,7 @@ func getBuckets(client s3iface.S3API) *s3.ListBucketsOutput {
 
 	result, err := client.ListBuckets(input)
 	if err != nil {
-		log.Fatal("Not able to get list of buckets", err)
+		log.Fatal("Not able to get list of S3 buckets ", err)
 	}
 
 	return result
@@ -33,7 +34,7 @@ func ParseS3Tags(tagsToRead string, client s3iface.S3API) [][]string {
 			} else if err.(awserr.Error).Code() == "AuthorizationHeaderMalformed" {
 				fmt.Println("Bucket ", *bucket.Name, "is not in your region", "region")
 			} else {
-				fmt.Println("Not able to get tags", err)
+				fmt.Println("Not able to get tags ", err)
 			}
 		}
 		tags := map[string]string{}


### PR DESCRIPTION
1. added two subcommands to ec2 for tagging SecurityGroups (SGs)
2. cleaned up linting issues w/ golint and gofmt
3. added trailing spaces to prepend log errors