### PR TITLE
Updated CloudWatch Logs

### DIFF
--- a/cmd/cloudwatch.go
+++ b/cmd/cloudwatch.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/sts"
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 // cloudwatchCmd represents the cloudwatch command

--- a/cmd/cloudwatch.go
+++ b/cmd/cloudwatch.go
@@ -22,7 +22,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/spf13/cobra"
+	"github.com/aws/aws-sdk-go/service/sts"
+    "github.com/spf13/cobra"
 )
 
 // cloudwatchCmd represents the cloudwatch command
@@ -49,7 +50,8 @@ Csv filename can be specified with flag filename.`,
 		region, _ := cmd.Flags().GetString("region")
 		sess := pkg.GetSession(region, profile)
 		client := cloudwatchlogs.New(sess)
-		pkg.WriteCsv(pkg.ParseCwLogGroupTags(tags, client), filename)
+		stsClient := sts.New(sess)
+		pkg.WriteCsv(pkg.ParseCwLogGroupTags(tags, client, stsClient, region), filename)
 	},
 }
 

--- a/pkg/cloudwatch.go
+++ b/pkg/cloudwatch.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/aws/aws-sdk-go/service/sts"
-    "github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 )
 
 // getCWAlarm return all CloudWatch alarms from specified region
@@ -74,16 +74,16 @@ func getCWLogGroups(client cloudwatchlogsiface.CloudWatchLogsAPI) []*cloudwatchl
 // ParseCwLogGroupTags parse output from getInstances and return Arn and specified tags.
 func ParseCwLogGroupTags(tagsToRead string, client cloudwatchlogsiface.CloudWatchLogsAPI, stsClient stsiface.STSAPI, region string) [][]string {
 	instancesOutput := getCWLogGroups(client)
-    callerIdentity, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-    if err != nil {
-        log.Fatal("Not able to get account id", err)
-    }
-    rows := addHeadersToCsv(tagsToRead, "Arn")
+	callerIdentity, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		log.Fatal("Not able to get account id", err)
+	}
+	rows := addHeadersToCsv(tagsToRead, "Arn")
 	for _, logGroup := range instancesOutput {
-        logGroupArn := fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s", region, *callerIdentity.Account, *logGroup.LogGroupName)
-        input := &cloudwatchlogs.ListTagsForResourceInput{
-            ResourceArn: aws.String(logGroupArn),
-        }
+		logGroupArn := fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s", region, *callerIdentity.Account, *logGroup.LogGroupName)
+		input := &cloudwatchlogs.ListTagsForResourceInput{
+			ResourceArn: aws.String(logGroupArn),
+		}
 		cwLogTags, err := client.ListTagsForResource(input)
 		if err != nil {
 			fmt.Println("Not able to get log group tags ", err)

--- a/pkg/cloudwatch.go
+++ b/pkg/cloudwatch.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
+	"github.com/aws/aws-sdk-go/service/sts"
+    "github.com/aws/aws-sdk-go/service/sts/stsiface"
 )
 
 // getCWAlarm return all CloudWatch alarms from specified region
@@ -69,16 +71,20 @@ func getCWLogGroups(client cloudwatchlogsiface.CloudWatchLogsAPI) []*cloudwatchl
 	return result
 }
 
-// ParseCwLogGroupTags parse output from getInstances and return logGroupName and specified tags.
-func ParseCwLogGroupTags(tagsToRead string, client cloudwatchlogsiface.CloudWatchLogsAPI) [][]string {
+// ParseCwLogGroupTags parse output from getInstances and return Arn and specified tags.
+func ParseCwLogGroupTags(tagsToRead string, client cloudwatchlogsiface.CloudWatchLogsAPI, stsClient stsiface.STSAPI, region string) [][]string {
 	instancesOutput := getCWLogGroups(client)
-	rows := addHeadersToCsv(tagsToRead, "LogGroupName")
+    callerIdentity, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+    if err != nil {
+        log.Fatal("Not able to get account id", err)
+    }
+    rows := addHeadersToCsv(tagsToRead, "Arn")
 	for _, logGroup := range instancesOutput {
-
-		input := &cloudwatchlogs.ListTagsLogGroupInput{
-			LogGroupName: logGroup.LogGroupName,
-		}
-		cwLogTags, err := client.ListTagsLogGroup(input)
+        logGroupArn := fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s", region, *callerIdentity.Account, *logGroup.LogGroupName)
+        input := &cloudwatchlogs.ListTagsForResourceInput{
+            ResourceArn: aws.String(logGroupArn),
+        }
+		cwLogTags, err := client.ListTagsForResource(input)
 		if err != nil {
 			fmt.Println("Not able to get log group tags ", err)
 		}
@@ -86,7 +92,7 @@ func ParseCwLogGroupTags(tagsToRead string, client cloudwatchlogsiface.CloudWatc
 		for key, value := range cwLogTags.Tags {
 			tags[key] = *value
 		}
-		rows = addTagsToCsv(tagsToRead, tags, rows, *logGroup.LogGroupName)
+		rows = addTagsToCsv(tagsToRead, tags, rows, logGroupArn)
 	}
 	return rows
 }
@@ -114,7 +120,7 @@ func TagCloudWatchAlarm(csvData [][]string, client cloudwatchiface.CloudWatchAPI
 	}
 }
 
-// TagCloudWatchLogGroups tag cloudwatch log groups. Take as input data from csv file. Where first column LogGroupName
+// TagCloudWatchLogGroups tag cloudwatch log groups. Take as input data from csv file. Where first column Arn
 func TagCloudWatchLogGroups(csvData [][]string, client cloudwatchlogsiface.CloudWatchLogsAPI) {
 	for r := 1; r < len(csvData); r++ {
 		tags := make(map[string]*string)
@@ -122,12 +128,12 @@ func TagCloudWatchLogGroups(csvData [][]string, client cloudwatchlogsiface.Cloud
 			tags[csvData[0][c]] = &csvData[r][c]
 		}
 
-		input := &cloudwatchlogs.TagLogGroupInput{
-			LogGroupName: aws.String(csvData[r][0]),
-			Tags:         tags,
+		input := &cloudwatchlogs.TagResourceInput{
+			ResourceArn: aws.String(csvData[r][0]),
+			Tags:        tags,
 		}
 
-		_, err := client.TagLogGroup(input)
+		_, err := client.TagResource(input)
 		if awsErrorHandle(err) {
 			return
 		}

--- a/pkg/cloudwatch_test.go
+++ b/pkg/cloudwatch_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
+    "github.com/aws/aws-sdk-go/service/sts"
+    "github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -91,8 +93,10 @@ var listCloudWatchAlarmsResp = cloudwatch.ListTagsForResourceOutput{
 
 type mockedCloudWatchLog struct {
 	cloudwatchlogsiface.CloudWatchLogsAPI
-	respDescribeLogGroups cloudwatchlogs.DescribeLogGroupsOutput
-	respListTagsLogGroup  cloudwatchlogs.ListTagsLogGroupOutput
+	stsiface.STSAPI
+	respDescribeLogGroups   cloudwatchlogs.DescribeLogGroupsOutput
+	respGetCallerIdentity   sts.GetCallerIdentityOutput
+	respListTagsForResource cloudwatchlogs.ListTagsForResourceOutput
 }
 
 func (m *mockedCloudWatchLog) DescribeLogGroupsPages(input *cloudwatchlogs.DescribeLogGroupsInput, pageFunc func(*cloudwatchlogs.DescribeLogGroupsOutput, bool) bool) error {
@@ -100,8 +104,12 @@ func (m *mockedCloudWatchLog) DescribeLogGroupsPages(input *cloudwatchlogs.Descr
 	return nil
 }
 
-func (m *mockedCloudWatchLog) ListTagsLogGroup(*cloudwatchlogs.ListTagsLogGroupInput) (*cloudwatchlogs.ListTagsLogGroupOutput, error) {
-	return &m.respListTagsLogGroup, nil
+func (m *mockedCloudWatchLog) GetCallerIdentity(*sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+	return &m.respGetCallerIdentity, nil
+}
+
+func (m *mockedCloudWatchLog) ListTagsForResource(*cloudwatchlogs.ListTagsForResourceInput) (*cloudwatchlogs.ListTagsForResourceOutput, error) {
+	return &m.respListTagsForResource, nil
 }
 
 func TestGetCWLogGroups(t *testing.T) {
@@ -126,19 +134,20 @@ func TestGetCWLogGroups(t *testing.T) {
 func TestParseCwLogGroupTags(t *testing.T) {
 	cases := []*mockedCloudWatchLog{
 		{
-			respDescribeLogGroups: describeCloudWatchLogGroupsResponse,
-			respListTagsLogGroup:  listCloudWatchLogsTagResponse,
+			respDescribeLogGroups:   describeCloudWatchLogGroupsResponse,
+			respGetCallerIdentity:   getCloudWatchCallerIdentityResponse,
+			respListTagsForResource: listCloudWatchLogsTagResponse,
 		},
 	}
 
 	expectedResult := [][]string{
-		{"LogGroupName", "Name", "Owner"},
-		{"test-log-group", "test-log-group", "mpostument"},
+        {"Arn", "Name", "Owner"},
+        {"arn:aws:logs:us-east-1:666666666:log-group:test-log-group", "test-log-group", "mpostument"},
 	}
 
 	for _, c := range cases {
 		t.Run("ParseCwLogGroupTags", func(t *testing.T) {
-			result := ParseCwLogGroupTags("Name,Owner", c)
+			result := ParseCwLogGroupTags("Name,Owner", c, c, "us-east-1")
 			assertions := assert.New(t)
 			assertions.EqualValues(expectedResult, result)
 		})
@@ -154,7 +163,11 @@ var describeCloudWatchLogGroupsResponse = cloudwatchlogs.DescribeLogGroupsOutput
 	},
 }
 
-var listCloudWatchLogsTagResponse = cloudwatchlogs.ListTagsLogGroupOutput{
+var getCloudWatchCallerIdentityResponse = sts.GetCallerIdentityOutput{
+	Account: aws.String("666666666"),
+}
+
+var listCloudWatchLogsTagResponse = cloudwatchlogs.ListTagsForResourceOutput{
 	Tags: map[string]*string{
 		"Name":  aws.String("test-log-group"),
 		"Owner": aws.String("mpostument"),

--- a/pkg/cloudwatch_test.go
+++ b/pkg/cloudwatch_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
-    "github.com/aws/aws-sdk-go/service/sts"
-    "github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -141,8 +141,8 @@ func TestParseCwLogGroupTags(t *testing.T) {
 	}
 
 	expectedResult := [][]string{
-        {"Arn", "Name", "Owner"},
-        {"arn:aws:logs:us-east-1:666666666:log-group:test-log-group", "test-log-group", "mpostument"},
+		{"Arn", "Name", "Owner"},
+		{"arn:aws:logs:us-east-1:666666666:log-group:test-log-group", "test-log-group", "mpostument"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
The ListTagsLogGroup and TagLogGroup operations in AWS CloudWatch Logs are marked for deprecation, and AWS is encouraging the use of newer alternatives.
I have replaced the ListTagsLogGroup and TagLogGroup operations with the new API.
https://docs.aws.amazon.com/ko_kr/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsLogGroup.html
https://docs.aws.amazon.com/ko_kr/AmazonCloudWatchLogs/latest/APIReference/API_TagLogGroup.html
